### PR TITLE
Genericize DLL loading code

### DIFF
--- a/examples/merge.py
+++ b/examples/merge.py
@@ -1,15 +1,36 @@
 #Merge example
+import os
+import platform
 import sys
 sys.path.insert(0,'..')
 import pycpdflib
 
-# DLL loading depends on your own platform. These are the author's settings.
+# DLL loading depends on your own platform.
+# The following DLL loading code assumes you've run:
+#   git clone https://github.com/coherentgraphics/cpdflib-binary
+#   git clone https://github.com/johnwhitington/cpdflib-source
+#   git clone https://github.com/coherentgraphics/python-libcpdf
+#   cd python-libcpdf/examples
+dll_root = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "cpdflib-binary"))
 if sys.platform.startswith('darwin'):
-    pycpdflib.loadDLL("/Users/john/repos/python-libcpdf/libpycpdf.so")
+    if platform.processor().startswith("arm"):
+        dll_dir = os.path.join(dll_root, "macosx-arm")
+    else:
+        dll_dir = os.path.join(dll_root, "macosx")
+    pycpdflib.loadDLL(os.path.join(dll_dir, "libpycpdf.so"))
 elif sys.platform.startswith('linux'):
-    pycpdflib.loadDLL("../libpycpdf.so")
-elif sys.platform.startswith('win32') or sys.platform.startswith('cygwin'):
-    os.add_dll_directory("C:\\\\OCaml64/home/JohnWhitington/python-libcpdf/")
+    if sys.maxsize > 2**32:
+        dll_dir = os.path.join(dll_root, "linux64")
+    else:
+        dll_dir = os.path.join(dll_root, "linux32")
+    pycpdflib.loadDLL(os.path.join(dll_dir, "libpycpdf.so"))
+elif os.name == "nt": # win32, cygwin, msys2, mingw, etc.
+    if sys.maxsize > 2**32:
+        dll_dir = os.path.join(dll_root, "windows64")
+    else:
+        dll_dir = os.path.join(dll_root, "windows32")
+    # pylint: disable=no-member
+    os.add_dll_directory(dll_dir) # type: ignore
     pycpdflib.loadDLL("libpycpdf.dll")
 
 #We will take the input hello.pdf and repeat it three times

--- a/examples/squeeze.py
+++ b/examples/squeeze.py
@@ -1,15 +1,36 @@
 #Squeeze example
+import os
+import platform
 import sys
 sys.path.insert(0,'..')
 import pycpdflib
 
-#DLL loading depends on your own platform. These are the author's settings.
+# DLL loading depends on your own platform.
+# The following DLL loading code assumes you've run:
+#   git clone https://github.com/coherentgraphics/cpdflib-binary
+#   git clone https://github.com/johnwhitington/cpdflib-source
+#   git clone https://github.com/coherentgraphics/python-libcpdf
+#   cd python-libcpdf/examples
+dll_root = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..", "cpdflib-binary"))
 if sys.platform.startswith('darwin'):
-    pycpdflib.loadDLL("/Users/john/repos/python-libcpdf/libpycpdf.so")
+    if platform.processor().startswith("arm"):
+        dll_dir = os.path.join(dll_root, "macosx-arm")
+    else:
+        dll_dir = os.path.join(dll_root, "macosx")
+    pycpdflib.loadDLL(os.path.join(dll_dir, "libpycpdf.so"))
 elif sys.platform.startswith('linux'):
-    pycpdflib.loadDLL("../libpycpdf.so")
-elif sys.platform.startswith('win32') or sys.platform.startswith('cygwin'):
-    os.add_dll_directory("C:\\\\OCaml64/home/JohnWhitington/python-libcpdf/")
+    if sys.maxsize > 2**32:
+        dll_dir = os.path.join(dll_root, "linux64")
+    else:
+        dll_dir = os.path.join(dll_root, "linux32")
+    pycpdflib.loadDLL(os.path.join(dll_dir, "libpycpdf.so"))
+elif os.name == "nt": # win32, cygwin, msys2, mingw, etc.
+    if sys.maxsize > 2**32:
+        dll_dir = os.path.join(dll_root, "windows64")
+    else:
+        dll_dir = os.path.join(dll_root, "windows32")
+    # pylint: disable=no-member
+    os.add_dll_directory(dll_dir) # type: ignore
     pycpdflib.loadDLL("libpycpdf.dll")
 
 #Load file

--- a/pycpdftest.py
+++ b/pycpdftest.py
@@ -1,16 +1,36 @@
 import pycpdflib
 import sys
 import os
+import platform
 import traceback
 import gc
 
-# DLL loading depends on your own platform. These are the author's settings.
+# DLL loading depends on your own platform.
+# The following DLL loading code assumes you've run:
+#   git clone https://github.com/coherentgraphics/cpdflib-binary
+#   git clone https://github.com/johnwhitington/cpdflib-source
+#   git clone https://github.com/coherentgraphics/python-libcpdf
+#   cd python-libcpdf
+dll_root = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "cpdflib-binary"))
 if sys.platform.startswith('darwin'):
-    pycpdflib.loadDLL("/Users/john/repos/python-libcpdf/libpycpdf.so")
+    if platform.processor().startswith("arm"):
+        dll_dir = os.path.join(dll_root, "macosx-arm")
+    else:
+        dll_dir = os.path.join(dll_root, "macosx")
+    pycpdflib.loadDLL(os.path.join(dll_dir, "libpycpdf.so"))
 elif sys.platform.startswith('linux'):
-    pycpdflib.loadDLL("libpycpdf.so")
-elif sys.platform.startswith('win32') or sys.platform.startswith('cygwin'):
-    os.add_dll_directory("C:\\\\OCaml64/home/JohnWhitington/python-libcpdf/")
+    if sys.maxsize > 2**32:
+        dll_dir = os.path.join(dll_root, "linux64")
+    else:
+        dll_dir = os.path.join(dll_root, "linux32")
+    pycpdflib.loadDLL(os.path.join(dll_dir, "libpycpdf.so"))
+elif os.name == "nt": # win32, cygwin, msys2, mingw, etc.
+    if sys.maxsize > 2**32:
+        dll_dir = os.path.join(dll_root, "windows64")
+    else:
+        dll_dir = os.path.join(dll_root, "windows32")
+    # pylint: disable=no-member
+    os.add_dll_directory(dll_dir) # type: ignore
     pycpdflib.loadDLL("libpycpdf.dll")
 
 


### PR DESCRIPTION
Tested on Windows, and Linux. On Linux, I first ran:
```bash
echo /home/ross/github/coherentgraphics/cpdflib-binary/linux64 | sudo tee /etc/ld.so.conf.d/cpdflib.conf
sudo ldconfig
```
Should I add the above to the code's comments?
